### PR TITLE
fix: add symfony/property-info in dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "license": "EUPL-1.2",
     "require": {
         "php": "^7.4 || ^8.0",
-        "sylius/sylius": "^1.9"
+        "sylius/sylius": "^1.9",
+        "symfony/property-info": "^5.4"
     },
     "require-dev": {
         "j13k/yaml-lint": "1.1.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes

Add the symfony/property-info in depency because we have a break in prod env.
